### PR TITLE
docs: créer et structurer CLAUDE.md pour Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# CLAUDE.md — Numa
+
+Règles essentielles pour Claude Code sur ce dépôt. Documentation détaillée dans `docs/claude/`.
+
+## Projet
+
+Numa : application web d'astrologie personnalisée (lectures compréhensibles, transparentes, non catégoriques).
+
+## Stack imposée
+
+React, TypeScript, Tailwind CSS, Supabase (Auth + PostgreSQL + RLS), GitHub Actions, déploiement OVH.
+
+## Règles essentielles
+
+- Workflow Git : `master` → `epic/<slug>/main` → `epic/<slug>/issue-<id>-<slug>`. Voir `docs/claude/git-workflow.md`.
+- Toute modification passe par une pull request. **Aucun merge automatique, jamais.** Voir `docs/claude/pull-requests.md`.
+- Tout nouveau fichier de logique ou composant significatif est accompagné de son test **dans la même PR**. Voir `docs/claude/development.md`.
+- Avant de considérer une tâche terminée : lint, typecheck, tests, couverture, build. Voir `docs/claude/development.md`.
+- Aucun secret, clé privée ou donnée personnelle commité. Voir `docs/claude/security.md`.
+- RLS obligatoire sur toute table Supabase exposée à des données utilisateur. Voir `docs/claude/supabase.md`.
+
+## Index de la documentation
+
+| Document | Contenu |
+|---|---|
+| `docs/claude/architecture.md` | Stack React, Tailwind CSS, Supabase, OVH, n8n |
+| `docs/claude/git-workflow.md` | Branches, PRs, statuts |
+| `docs/claude/development.md` | Commandes, qualité, tests, conventions de code |
+| `docs/claude/supabase.md` | Auth, sessions anonymes, PostgreSQL, migrations, RLS |
+| `docs/claude/ai-astrology.md` | API astrologique, IA, contexte structuré, règles éditoriales |
+| `docs/claude/security.md` | Secrets, données personnelles, rate limiting, logs |
+| `docs/claude/pull-requests.md` | Création de PR, corrections, notifications, interdiction de merge auto |
+| `docs/claude/decision-log.md` | Décisions d'architecture et règles évolutives |
+
+Consulter le document spécialisé concerné avant toute tâche touchant à son périmètre.

--- a/docs/claude/ai-astrology.md
+++ b/docs/claude/ai-astrology.md
@@ -1,0 +1,18 @@
+# IA & Astrologie
+
+## API astrologique
+
+- Les calculs astrologiques (positions planétaires, thème natal, etc.) passent par une API astrologique dédiée, appelée côté serveur.
+- Les clés d'accès à cette API restent côté serveur, jamais exposées au client. Voir `security.md`.
+
+## Génération IA
+
+- Les lectures textuelles sont générées à partir d'un contexte structuré (données astrologiques calculées + profil utilisateur), pas d'un prompt libre non contrôlé.
+- Le contexte envoyé au modèle est explicite et traçable (pas de "prompt magique" caché).
+
+## Règles éditoriales
+
+- Les lectures sont **compréhensibles** : langage clair, pas de jargon non expliqué.
+- Les lectures sont **transparentes** : la base (données astrologiques utilisées) reste accessible/consultable par l'utilisateur.
+- Les lectures sont **non catégoriques** : pas d'affirmations absolues sur l'avenir ou la personnalité ; formulation en tendances et possibilités.
+- Pas de contenu à caractère médical, financier ou juridique présenté comme un conseil.

--- a/docs/claude/architecture.md
+++ b/docs/claude/architecture.md
@@ -1,0 +1,20 @@
+# Architecture
+
+## Stack
+
+- **React** : composants fonctionnels, TypeScript strict (pas de `any`).
+- **TypeScript** : typage strict activé sur tout le code applicatif.
+- **Tailwind CSS** : styling utilitaire, pas de CSS custom sauf nécessité justifiée.
+- **Supabase** : Auth, base PostgreSQL, RLS. Voir `supabase.md`.
+- **OVH** : hébergement/déploiement de l'application.
+- **n8n** : automatisations/orchestration hors application principale (workflows, intégrations).
+
+## Principes
+
+- Pas d'abstraction anticipée : construire pour le besoin actuel, pas pour un besoin hypothétique.
+- Composants et hooks typés explicitement (props, retours de hooks).
+- Logique métier séparée de la présentation quand elle dépasse quelques lignes.
+
+## Astrologie / IA
+
+Voir `ai-astrology.md` pour l'intégration de l'API astrologique et des appels IA.

--- a/docs/claude/decision-log.md
+++ b/docs/claude/decision-log.md
@@ -1,0 +1,21 @@
+# Journal de décisions
+
+Décisions d'architecture et règles évolutives du projet Numa. Ajouter une entrée à chaque décision structurante, la plus récente en premier.
+
+## Format d'entrée
+
+```
+## AAAA-MM-JJ — Titre de la décision
+
+Contexte : pourquoi la question se posait.
+Décision : ce qui a été choisi.
+Alternatives écartées : le cas échéant.
+```
+
+## Entrées
+
+## 2026-08-21 — Structuration de CLAUDE.md
+
+Contexte : besoin d'encadrer Claude Code sans concentrer toute la documentation dans un seul fichier long (issue #58).
+Décision : `CLAUDE.md` court à la racine + documents spécialisés sous `docs/claude/` (architecture, git-workflow, development, supabase, ai-astrology, security, pull-requests, decision-log), indexés depuis `CLAUDE.md`.
+Alternatives écartées : un unique fichier `CLAUDE.md` exhaustif — jugé moins maintenable dans la durée.

--- a/docs/claude/development.md
+++ b/docs/claude/development.md
@@ -1,0 +1,32 @@
+# Développement
+
+## Commandes de validation
+
+```bash
+npm run lint
+npm run typecheck
+npm run test
+npm run test:coverage
+npm run build
+```
+
+Ces commandes doivent passer avant de considérer une tâche terminée ou une PR prête pour review.
+
+## Tests
+
+- Tout nouveau fichier de logique (hook, service, utilitaire) ou composant React significatif est accompagné de son test **dans la même pull request**. Pas de "je rajouterai les tests plus tard".
+- Tests via React Testing Library pour les composants.
+- Pas de mock de ce qui peut être testé en réel de façon fiable et rapide.
+
+## Conventions de code
+
+- TypeScript strict, pas de `any`.
+- Composants : `PascalCase`. Hooks, fonctions, variables : `camelCase`.
+- Props de composant typées via `interface Props`.
+- `useEffect`/`useCallback`/`useMemo` : dependency arrays complètes et exactes.
+- Pas de duplication évitable ; pas d'abstraction créée avant qu'un second usage réel existe.
+- Pas de code mort, pas de commentaire expliquant le "quoi" (le nom du code doit suffire) — commentaire seulement si le "pourquoi" est non évident.
+
+## Couverture
+
+La couverture (`npm run test:coverage`) est vérifiée sur toute PR ajoutant de la logique. Pas de seuil arbitraire fixé ici — voir `decision-log.md` si un seuil est décidé plus tard.

--- a/docs/claude/git-workflow.md
+++ b/docs/claude/git-workflow.md
@@ -1,0 +1,28 @@
+# Workflow Git
+
+## Structure des branches
+
+```
+master
+ └── epic/<slug>/main
+      └── epic/<slug>/issue-<id>-<slug>
+```
+
+- `master` : branche stable, toujours déployable.
+- `epic/<slug>/main` : branche d'intégration d'une epic. Reçoit les PRs des tickets de l'epic.
+- `epic/<slug>/issue-<id>-<slug>` : branche de travail d'un ticket unique. Créée depuis `epic/<slug>/main` (ou `master` si pas d'epic active).
+
+## Règles
+
+- Une branche de travail traite **un seul ticket**.
+- Toute modification passe par une pull request : jamais de commit direct sur `master` ou `epic/<slug>/main`.
+- **Aucun merge automatique**, quel que soit le contexte (CI verte, review approuvée, etc.). Voir `pull-requests.md`.
+- La CI doit être verte et une revue humaine obtenue avant tout merge.
+- Une PR de ticket cible `epic/<slug>/main` (ou `master` si le ticket n'appartient pas à une epic).
+- Une PR d'epic (`epic/<slug>/main` → `master`) est ouverte une fois l'epic complète.
+
+## Statuts
+
+- PR ouverte : travail en cours ou prêt pour review.
+- PR en review : attend une revue humaine.
+- PR approuvée + CI verte : prête à merger — merge reste une action humaine explicite.

--- a/docs/claude/pull-requests.md
+++ b/docs/claude/pull-requests.md
@@ -1,0 +1,20 @@
+# Pull Requests
+
+## Création
+
+- Une PR par ticket, depuis `epic/<slug>/issue-<id>-<slug>` vers `epic/<slug>/main` (ou `master` si pas d'epic).
+- Description de PR claire : objectif, changements, plan de test.
+- Tests inclus dans la même PR que le code qu'ils couvrent.
+
+## Corrections
+
+- Les retours de review sont traités par nouveaux commits sur la même branche, pas par rebase forcé destructif sauf demande explicite.
+- CI doit repasser verte après chaque correction.
+
+## Notifications
+
+- Le ticket GitHub lié est référencé dans la PR (ex. `Closes #58`) quand la PR clôt le ticket.
+
+## Interdiction de merge automatique
+
+**Aucune PR n'est mergée automatiquement, sous aucune condition** (CI verte, review approuvée, urgence perçue). Le merge est toujours une action humaine explicite, déclenchée par l'utilisateur ou une personne autorisée du projet. Claude Code ne merge jamais une PR de sa propre initiative.

--- a/docs/claude/security.md
+++ b/docs/claude/security.md
@@ -1,0 +1,22 @@
+# Sécurité
+
+## Secrets
+
+- Aucun secret, clé API, clé privée ou token n'est commité dans le dépôt, sous quelque forme que ce soit (fichier `.env` commité, valeur en dur dans le code, fixture de test).
+- Les clés sensibles (Supabase service role, API astrologique, IA) restent côté serveur uniquement.
+- Avant tout commit, vérifier le contenu des fichiers ajoutés, même si le nom de fichier semble anodin.
+
+## Données personnelles
+
+- Données utilisateur (date/heure/lieu de naissance, lectures générées) protégées par RLS. Voir `supabase.md`.
+- Pas de log de données personnelles en clair.
+- Pas de transmission de données personnelles à un service tiers non explicitement validé pour cet usage.
+
+## Rate limiting
+
+- Les appels aux API externes coûteuses (astrologie, IA) sont soumis à rate limiting côté serveur pour éviter abus et dérive de coût.
+
+## Logs
+
+- Logs applicatifs sans données personnelles ni secrets.
+- Logs d'erreur suffisamment détaillés pour debug (stack, contexte technique) sans contenu utilisateur sensible.

--- a/docs/claude/supabase.md
+++ b/docs/claude/supabase.md
@@ -1,0 +1,22 @@
+# Supabase
+
+## Auth
+
+- Authentification via Supabase Auth.
+- Sessions anonymes supportées pour permettre l'usage sans compte (lecture astrologique avant inscription) ; migration vers compte identifié gère la conservation des données déjà produites.
+
+## PostgreSQL
+
+- Schéma versionné via migrations Supabase (`supabase/migrations`).
+- Pas de modification de schéma en production hors migration versionnée.
+
+## RLS (Row Level Security)
+
+- **RLS activé sur toute table contenant des données utilisateur.**
+- Une table sans RLS n'est acceptée que si elle ne contient aucune donnée liée à un utilisateur (référentiel public, config statique) — à justifier explicitement dans la PR.
+- Policies testées : un utilisateur ne doit jamais pouvoir lire/modifier les données d'un autre utilisateur, y compris en session anonyme.
+
+## Migrations
+
+- Chaque migration est un fichier versionné dans le dépôt, appliqué via l'outillage Supabase.
+- Pas de migration destructive (drop de colonne/table contenant des données) sans validation humaine explicite.


### PR DESCRIPTION
## Résumé

- CLAUDE.md court à la racine avec règles essentielles + index vers docs/claude/.
- 8 documents spécialisés sous docs/claude/ : architecture, git-workflow, development, supabase, ai-astrology, security, pull-requests, decision-log.
- Documente stack (React, TypeScript, Tailwind CSS, Supabase), workflow master → epic/main → epic/issue, obligation de tests dans la même PR, commandes lint/typecheck/test/coverage/build, interdiction de merge automatique.
- Aucune fonctionnalité produit ajoutée.

Closes #58

## Test plan

- [x] Liens et chemins de l'index CLAUDE.md vérifiés cohérents avec docs/claude/.
- [x] Aucun secret commité.
- [ ] Revue humaine.