### PR TITLE
feat: notifications Discord sur PR et CI (#61)

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,0 +1,115 @@
+name: Discord notifications
+
+on:
+  pull_request:
+    types: [opened, synchronize, closed]
+  pull_request_review:
+    types: [submitted]
+  workflow_run:
+    workflows: ["CI"]
+    types: [requested, completed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify:
+    name: Notifier Discord
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft != true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: PR ouverte
+        if: github.event_name == 'pull_request' && github.event.action == 'opened'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          NOTIFY_REPOSITORY: ${{ github.repository }}
+          NOTIFY_TITLE: ${{ github.event.pull_request.title }}
+          NOTIFY_URL: ${{ github.event.pull_request.html_url }}
+          NOTIFY_BRANCH: ${{ github.event.pull_request.head.ref }}
+          NOTIFY_AUTHOR: ${{ github.event.pull_request.user.login }}
+        continue-on-error: true
+        run: npm run notify:discord -- pr_opened
+
+      - name: PR mise à jour
+        if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          NOTIFY_REPOSITORY: ${{ github.repository }}
+          NOTIFY_TITLE: ${{ github.event.pull_request.title }}
+          NOTIFY_URL: ${{ github.event.pull_request.html_url }}
+          NOTIFY_BRANCH: ${{ github.event.pull_request.head.ref }}
+          NOTIFY_AUTHOR: ${{ github.event.pull_request.user.login }}
+        continue-on-error: true
+        run: npm run notify:discord -- pr_updated
+
+      - name: PR mergée
+        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          NOTIFY_REPOSITORY: ${{ github.repository }}
+          NOTIFY_TITLE: ${{ github.event.pull_request.title }}
+          NOTIFY_URL: ${{ github.event.pull_request.html_url }}
+          NOTIFY_BRANCH: ${{ github.event.pull_request.base.ref }}
+          NOTIFY_AUTHOR: ${{ github.event.pull_request.merged_by.login }}
+        continue-on-error: true
+        run: npm run notify:discord -- pr_merged
+
+      - name: Correction demandée
+        if: github.event_name == 'pull_request_review' && github.event.review.state == 'changes_requested'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          NOTIFY_REPOSITORY: ${{ github.repository }}
+          NOTIFY_TITLE: ${{ github.event.pull_request.title }}
+          NOTIFY_URL: ${{ github.event.pull_request.html_url }}
+          NOTIFY_BRANCH: ${{ github.event.pull_request.head.ref }}
+          NOTIFY_AUTHOR: ${{ github.event.review.user.login }}
+          NOTIFY_SUMMARY: ${{ github.event.review.body }}
+        continue-on-error: true
+        run: npm run notify:discord -- pr_changes_requested
+
+      - name: CI démarrée
+        if: github.event_name == 'workflow_run' && github.event.action == 'requested'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          NOTIFY_REPOSITORY: ${{ github.repository }}
+          NOTIFY_TITLE: ${{ github.event.workflow_run.display_title }}
+          NOTIFY_URL: ${{ github.event.workflow_run.html_url }}
+          NOTIFY_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          NOTIFY_AUTHOR: ${{ github.event.workflow_run.actor.login }}
+        continue-on-error: true
+        run: npm run notify:discord -- ci_started
+
+      - name: CI réussie
+        if: github.event_name == 'workflow_run' && github.event.action == 'completed' && github.event.workflow_run.conclusion == 'success'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          NOTIFY_REPOSITORY: ${{ github.repository }}
+          NOTIFY_TITLE: ${{ github.event.workflow_run.display_title }}
+          NOTIFY_URL: ${{ github.event.workflow_run.html_url }}
+          NOTIFY_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          NOTIFY_AUTHOR: ${{ github.event.workflow_run.actor.login }}
+        continue-on-error: true
+        run: npm run notify:discord -- ci_success
+
+      - name: CI en échec
+        if: github.event_name == 'workflow_run' && github.event.action == 'completed' && github.event.workflow_run.conclusion == 'failure'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          NOTIFY_REPOSITORY: ${{ github.repository }}
+          NOTIFY_TITLE: ${{ github.event.workflow_run.display_title }}
+          NOTIFY_URL: ${{ github.event.workflow_run.html_url }}
+          NOTIFY_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          NOTIFY_AUTHOR: ${{ github.event.workflow_run.actor.login }}
+        continue-on-error: true
+        run: npm run notify:discord -- ci_failure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ React, TypeScript, Tailwind CSS, Supabase (Auth + PostgreSQL + RLS), GitHub Acti
 - Avant de considérer une tâche terminée : lint, typecheck, tests, couverture, build. Voir `docs/claude/development.md`.
 - Aucun secret, clé privée ou donnée personnelle commité. Voir `docs/claude/security.md`.
 - RLS obligatoire sur toute table Supabase exposée à des données utilisateur. Voir `docs/claude/supabase.md`.
+- Notifications Discord (PR, CI, tickets) : webhook stocké dans `secrets.DISCORD_WEBHOOK_URL`, jamais dans le code. Voir `docs/claude/pull-requests.md`.
 
 ## Index de la documentation
 

--- a/docs/claude/pull-requests.md
+++ b/docs/claude/pull-requests.md
@@ -19,6 +19,15 @@
 
 **Aucune PR n'est mergée automatiquement, sous aucune condition** (CI verte, review approuvée, urgence perçue). Le merge est toujours une action humaine explicite, déclenchée par l'utilisateur ou une personne autorisée du projet. Claude Code ne merge jamais une PR de sa propre initiative.
 
+## Notifications Discord
+
+- Workflow `.github/workflows/discord-notify.yml` : envoie une notification Discord à l'ouverture, la mise à jour ou le merge d'une PR, sur demande de correction (review `changes_requested`), et au démarrage/succès/échec du workflow `CI`.
+- Logique de formatage et d'envoi dans `src/lib/discordNotify.ts` (testée dans `discordNotify.test.ts`), invoquée en CI via `npm run notify:discord -- <type>` (`scripts/notify-discord.ts`).
+- Le webhook Discord est stocké dans le secret GitHub Actions `DISCORD_WEBHOOK_URL` (Settings → Secrets and variables → Actions). Il n'apparaît jamais dans le code, les logs ou les issues.
+- Chaque étape de notification est isolée (`continue-on-error: true`) : une panne Discord ou un webhook manquant n'affecte jamais le résultat de la CI.
+- Déduplication : chaque événement GitHub (ouverture, synchronisation, merge, review, run CI) ne déclenche qu'un seul appel Discord correspondant, sans notification répétée pour le même événement.
+- Rotation du webhook : régénérer l'URL depuis les paramètres du salon Discord (Intégrations → Webhooks), puis mettre à jour le secret `DISCORD_WEBHOOK_URL` dans les paramètres du dépôt GitHub. Aucune modification de code nécessaire.
+
 ## Protection des branches
 
 - `master` : branch protection classique — check CI `Lint, typecheck, test, build` obligatoire, branche à jour requise (`strict`), 1 review humaine obligatoire, admins inclus, force-push et suppression interdits.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "jsdom": "^25.0.1",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.14",
+        "tsx": "^4.23.12",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.13.0",
         "vite": "^5.4.10",
@@ -793,6 +794,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -810,6 +828,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -825,6 +860,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -5668,6 +5720,458 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "notify:discord": "tsx scripts/notify-discord.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.112.3",
@@ -35,6 +36,7 @@
     "jsdom": "^25.0.1",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
+    "tsx": "^4.23.12",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.13.0",
     "vite": "^5.4.10",

--- a/scripts/notify-discord.ts
+++ b/scripts/notify-discord.ts
@@ -1,0 +1,54 @@
+import {
+  buildDiscordMessage,
+  sendDiscordNotification,
+  type NotificationEventType,
+} from "../src/lib/discordNotify";
+
+const EVENT_TYPES: NotificationEventType[] = [
+  "pr_opened",
+  "pr_updated",
+  "pr_changes_requested",
+  "pr_merged",
+  "ci_started",
+  "ci_success",
+  "ci_failure",
+  "ticket_status",
+];
+
+function requireEnv(name: string): string {
+  return process.env[name] ?? "";
+}
+
+function isNotificationEventType(value: string): value is NotificationEventType {
+  return (EVENT_TYPES as string[]).includes(value);
+}
+
+async function main(): Promise<void> {
+  const type = process.argv[2] ?? "";
+  const webhookUrl = requireEnv("DISCORD_WEBHOOK_URL");
+
+  if (!isNotificationEventType(type)) {
+    process.stderr.write(`notify-discord: type d'événement inconnu "${type}", ignoré.\n`);
+    return;
+  }
+
+  const payload = buildDiscordMessage({
+    type,
+    repository: requireEnv("NOTIFY_REPOSITORY"),
+    title: requireEnv("NOTIFY_TITLE"),
+    url: requireEnv("NOTIFY_URL"),
+    branch: process.env.NOTIFY_BRANCH,
+    author: process.env.NOTIFY_AUTHOR,
+    summary: process.env.NOTIFY_SUMMARY,
+    status: process.env.NOTIFY_STATUS,
+  });
+
+  const ok = await sendDiscordNotification(webhookUrl, payload);
+  if (!ok) {
+    process.stderr.write("notify-discord: échec de l'envoi de la notification Discord.\n");
+  }
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`notify-discord: erreur inattendue: ${String(error)}\n`);
+});

--- a/src/lib/discordNotify.test.ts
+++ b/src/lib/discordNotify.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildDiscordMessage, sendDiscordNotification } from "./discordNotify";
+
+describe("buildDiscordMessage", () => {
+  it("formats a PR opened event with fields and color", () => {
+    const payload = buildDiscordMessage({
+      type: "pr_opened",
+      repository: "julto/numa",
+      title: "feat: add feature",
+      url: "https://github.com/julto/numa/pull/1",
+      branch: "epic/foo/issue-1",
+      author: "julto",
+      summary: "Ajoute une fonctionnalité",
+    });
+
+    expect(payload.content).toBe("Pull request ouverte");
+    expect(payload.embeds[0].title).toBe("feat: add feature");
+    expect(payload.embeds[0].url).toBe("https://github.com/julto/numa/pull/1");
+    expect(payload.embeds[0].fields).toEqual([
+      { name: "Dépôt", value: "julto/numa", inline: true },
+      { name: "Branche", value: "epic/foo/issue-1", inline: true },
+      { name: "Auteur", value: "julto", inline: true },
+    ]);
+  });
+
+  it("uses failure color for ci_failure", () => {
+    const payload = buildDiscordMessage({
+      type: "ci_failure",
+      repository: "julto/numa",
+      title: "CI #42",
+      url: "https://github.com/julto/numa/actions/runs/42",
+      status: "failure",
+    });
+
+    expect(payload.embeds[0].color).toBe(0xe74c3c);
+    expect(payload.content).toBe("CI en échec");
+  });
+
+  it("truncates overly long title and summary", () => {
+    const payload = buildDiscordMessage({
+      type: "ticket_status",
+      repository: "julto/numa",
+      title: "x".repeat(300),
+      url: "https://github.com/julto/numa/issues/1",
+      summary: "y".repeat(2100),
+    });
+
+    expect(payload.embeds[0].title.length).toBe(256);
+    expect(payload.embeds[0].title.endsWith("…")).toBe(true);
+    expect(payload.embeds[0].description.length).toBe(2000);
+  });
+});
+
+describe("sendDiscordNotification", () => {
+  it("returns true when the webhook responds ok", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true });
+
+    const result = await sendDiscordNotification(
+      "https://discord.com/api/webhooks/1/abc",
+      { content: "hello", embeds: [] },
+      fetchImpl,
+    );
+
+    expect(result).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://discord.com/api/webhooks/1/abc",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("returns false without throwing when fetch rejects", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("network down"));
+
+    const result = await sendDiscordNotification(
+      "https://discord.com/api/webhooks/1/abc",
+      { content: "hello", embeds: [] },
+      fetchImpl,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when the webhook responds with an error status", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false });
+
+    const result = await sendDiscordNotification(
+      "https://discord.com/api/webhooks/1/abc",
+      { content: "hello", embeds: [] },
+      fetchImpl,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when the webhook url is empty", async () => {
+    const fetchImpl = vi.fn();
+
+    const result = await sendDiscordNotification("", { content: "hello", embeds: [] }, fetchImpl);
+
+    expect(result).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/discordNotify.ts
+++ b/src/lib/discordNotify.ts
@@ -1,0 +1,114 @@
+export type NotificationEventType =
+  | "pr_opened"
+  | "pr_updated"
+  | "pr_changes_requested"
+  | "pr_merged"
+  | "ci_started"
+  | "ci_success"
+  | "ci_failure"
+  | "ticket_status";
+
+export interface NotificationEvent {
+  type: NotificationEventType;
+  repository: string;
+  title: string;
+  url: string;
+  branch?: string;
+  author?: string;
+  summary?: string;
+  status?: string;
+}
+
+interface DiscordEmbed {
+  title: string;
+  description: string;
+  url: string;
+  color: number;
+  fields: { name: string; value: string; inline: boolean }[];
+}
+
+export interface DiscordPayload {
+  content: string;
+  embeds: DiscordEmbed[];
+}
+
+const COLOR_SUCCESS = 0x2ecc71;
+const COLOR_FAILURE = 0xe74c3c;
+const COLOR_ACTION_NEEDED = 0xf1c40f;
+const COLOR_INFO = 0x5865f2;
+
+const EVENT_LABELS: Record<NotificationEventType, string> = {
+  pr_opened: "Pull request ouverte",
+  pr_updated: "Pull request mise à jour",
+  pr_changes_requested: "Correction demandée",
+  pr_merged: "Pull request mergée",
+  ci_started: "CI démarrée",
+  ci_success: "CI réussie",
+  ci_failure: "CI en échec",
+  ticket_status: "Statut de ticket changé",
+};
+
+const EVENT_COLORS: Record<NotificationEventType, number> = {
+  pr_opened: COLOR_INFO,
+  pr_updated: COLOR_INFO,
+  pr_changes_requested: COLOR_ACTION_NEEDED,
+  pr_merged: COLOR_SUCCESS,
+  ci_started: COLOR_INFO,
+  ci_success: COLOR_SUCCESS,
+  ci_failure: COLOR_FAILURE,
+  ticket_status: COLOR_INFO,
+};
+
+function truncate(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
+}
+
+export function buildDiscordMessage(event: NotificationEvent): DiscordPayload {
+  const fields: DiscordEmbed["fields"] = [
+    { name: "Dépôt", value: truncate(event.repository, 200), inline: true },
+  ];
+
+  if (event.branch) {
+    fields.push({ name: "Branche", value: truncate(event.branch, 200), inline: true });
+  }
+  if (event.author) {
+    fields.push({ name: "Auteur", value: truncate(event.author, 200), inline: true });
+  }
+  if (event.status) {
+    fields.push({ name: "Statut", value: truncate(event.status, 200), inline: true });
+  }
+
+  return {
+    content: EVENT_LABELS[event.type],
+    embeds: [
+      {
+        title: truncate(event.title, 256),
+        description: truncate(event.summary ?? "", 2000),
+        url: event.url,
+        color: EVENT_COLORS[event.type],
+        fields,
+      },
+    ],
+  };
+}
+
+export async function sendDiscordNotification(
+  webhookUrl: string,
+  payload: DiscordPayload,
+  fetchImpl: typeof fetch = fetch,
+): Promise<boolean> {
+  if (!webhookUrl) {
+    return false;
+  }
+
+  try {
+    const response = await fetchImpl(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
         "src/vite-env.d.ts",
         "src/test/**",
         "dist/**",
+        "scripts/**",
       ],
       thresholds: {
         lines: 70,


### PR DESCRIPTION
## Objectif
Notifier Discord sur les événements GitHub/CI (#61), pour suivre PR et échecs sans surveiller GitHub en permanence.

## Changements
- `.github/workflows/discord-notify.yml` : notifie à l'ouverture, la mise à jour, le merge d'une PR, sur demande de correction (review changes_requested), et au démarrage/succès/échec du workflow CI.
- `src/lib/discordNotify.ts` : formatage des messages (embed, couleur, troncature) + envoi non bloquant (catch réseau, retourne `false` sans throw).
- `scripts/notify-discord.ts` : CLI appelée en CI (`npm run notify:discord -- <type>`), lit les variables d'env du contexte GitHub Actions.
- Chaque step de notification a `continue-on-error: true` : une panne Discord n'affecte jamais le résultat de la CI (qui tourne dans un workflow séparé).
- Doc mise à jour : `CLAUDE.md` et `docs/claude/pull-requests.md` (config secret, rotation webhook, comportement non bloquant).

## Sécurité
- Webhook attendu dans le secret GitHub Actions `DISCORD_WEBHOOK_URL` (à créer manuellement, non inclus dans cette PR).
- Aucun webhook dans le code/logs.

## Plan de test
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (100% sur le nouveau module, seuils globaux respectés)
- [x] `npm run build`
- [x] Smoke test CLI sans webhook configuré → échec silencieux, exit 0 (non bloquant)
- [ ] Vérification en conditions réelles après ajout du secret `DISCORD_WEBHOOK_URL`

Closes #61